### PR TITLE
#162112251 Add the page view for admin panel records

### DIFF
--- a/admin-all-records.html
+++ b/admin-all-records.html
@@ -2,12 +2,26 @@
 <html>
 <head>
 <title>My Records - iReporter</title>
-<meta name="viewport" content="width=device-width, initial-scale=1">
 
 <link rel="stylesheet" href="style.css" type="text/css">
 
 </head>
 <body>
+
+  
+   <!-- navbar-->
+<div class="topnav">
+    
+      <a class="active" href="t" >iReporter</a> 
+      <a href="admin-login.html" ">Admin</a>
+      
+      <!-- Right-sided navbar links -->
+      <div class="topnav-smallText">
+         <a href="#"> About</a>
+         <a href="#" >FAQ</a>
+         <a href="#">Contact</a>
+      </div>     
+</div>
 
 <div id="container" >
 
@@ -15,42 +29,49 @@
         <h1>iReporter </h1>
        </div>
 
-       <div class=forminfo>Admin Panel</div>
+       <div class="title-head">Admin Panel</div>
 
-       <p>
-       <p>
-<table style="width:100%"  >
-    <caption><b>Red-Flags</b></caption> <br>
-      <tr>
-        <th>Index</th>
-        <th>Title</th>
-        <th>Description</th>
-        <th>Status</th> 
-        <th>User</th>
-        <th>Update Status</th>
+
+          <div class="tab">
+            <button class="tablinks" onclick="openRecord(event, 'red-flag')" id="defaultOpen">Red Flags</button>
+            <button class="tablinks" onclick="openRecord(event, 'intervention')">Interventions</button>
+
+            <div id="red-flag" class="tabcontent">
+
+               <table >
+                <caption><b>Red-Flags</b></caption> <br>
+                 <tr>
+                  <th>Index</th>
+                   <th>Title</th>
+                   <th>Description</th>
+                   <th>Status</th> 
+                   <th>User</th>
+                  <th>Update Status</th>
     
-      </tr>
-      <tr>
-        <td></td>
-        <td></td>
-        <td></td>
-        <td></td>
-        <td></td>
-        <td>
-            <select> 
-                <option value="" >Under Investigation</option>
-                <option value="" >Resolved</option>
-                <option value="" >Rejected</option>
-            </select>        </td>
-      </tr>
+                 </tr>
+                 <tr>
+                    <td></td>
+                    <td></td>
+                    <td></td>
+                    <td></td>
+                    <td></td>
+                    <td>
+                       <select> 
+                          <option value="" ><a href='#'>Under Investigation</a></option>
+                          <option value="" >Resolved</option>
+                          <option value="" >Rejected</option>
+                        </select>        
+                    </td>
+                  </tr>
   
-    </table>
+               </table>
+            </div>
 
-    <p>
-            <p>
-     <table style="width:100%">
-         <caption><b>Interventions</b></caption> <br>
-           <tr>
+            <div id="intervention" class="tabcontent">
+     
+               <table >
+               <caption><b>Interventions</b></caption> <br>
+              <tr>
              <th>Index</th>
              <th>Title</th>
              <th>Description</th>
@@ -58,8 +79,8 @@
              <th>User</th>
              <th>Update Status</th>
          
-           </tr>
-           <tr>
+            </tr>
+            <tr>
              <td></td>
              <td></td>
              <td></td>
@@ -73,8 +94,35 @@
                  </select>        </td>
            </tr>
        
-         </table>
+           </table>
+        </div>  
+
+
+      <div id="footer"> </div>  
 </div>
+
+
+<!-- JS script for tabifying red-flag and intervention records-->
+
+<script>
+function openRecord(evt, RecordName) {
+    var i, tabcontent, tablinks;
+    tabcontent = document.getElementsByClassName("tabcontent");
+    for (i = 0; i < tabcontent.length; i++) {
+        tabcontent[i].style.display = "none";
+    }
+    tablinks = document.getElementsByClassName("tablinks");
+    for (i = 0; i < tablinks.length; i++) {
+        tablinks[i].className = tablinks[i].className.replace(" active", "");
+    }
+    document.getElementById(RecordName).style.display = "block";
+    evt.currentTarget.className += " active";
+}
+
+// Get the element with id="defaultOpen" and click on it
+document.getElementById("defaultOpen").click();
+</script>
+
 
 </body>
 </html>


### PR DESCRIPTION
**What does this PR do?**
Have the admin panel page updated with records in tabs
**Description of Task to be completed?**
Have tabs for red-flags and interventions used for the admin panel views

**How should this be manually tested?**
After cloning the repo, cd into it and open UI/admin-all-records.html on a browser

**Any background context you want to provide?**
The functionality of the page not yet implemented 

**What are the relevant pivotal tracker stories?**
#162112251

**Screenshots**
![image](https://user-images.githubusercontent.com/26007662/48986549-b0fa1c80-f127-11e8-8163-61ba42a44b66.png)
